### PR TITLE
opentelemetry-instrumentation-bedrock 0.49.6 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-bedrock" %}
-{% set version = "0.47.2" %}
+{% set version = "0.49.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 3cfb7b12ba6f1e503b7c34c6a519655de65b7b04ad27e99223a5800987ecd105
+  sha256: 3175f292706827b939ebcad3acff7013cb389192e57c18afea1f0b93819b80cc
 
 build:
   number: 0
@@ -21,9 +21,9 @@ requirements:
     - poetry-core
   run:
     - python
-    - opentelemetry-api >=1.28.0,<2.0.0
-    - opentelemetry-instrumentation >=0.55b0
-    - opentelemetry-semantic-conventions >=0.55b0
+    - opentelemetry-api >=1.38.0,<2.0.0
+    - opentelemetry-instrumentation >=0.59b0
+    - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
     - anthropic >=0.17.0
     - tokenizers >=0.13.0


### PR DESCRIPTION
opentelemetry-instrumentation-bedrock 0.49.6 

**Destination channel:** Defaults

### Links

- [PKG-11110]
- dev_url:        https://github.com/traceloop/openllmetry/tree/0.49.6
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-bedrock-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-bedrock/0.49.6
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-bedrock/0.49.6

### Explanation of changes:

- new version number


[PKG-11110]: https://anaconda.atlassian.net/browse/PKG-11110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ